### PR TITLE
changed propType of 'toolbar' to Array

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -23,7 +23,7 @@ var QuillComponent = React.createClass({
 		value:        T.string,
 		defaultValue: T.string,
 		readOnly:     T.bool,
-		toolbar:      T.object,
+		toolbar:      T.array,
 		formats:      T.array,
 		styles:       T.object,
 		theme:        T.string,


### PR DESCRIPTION
The propType was wrongly set to 'object' and it generated warnings in the console while working perfectly fine :)

cheery, Andy