### PR TITLE
expose editor's getText to onChange prop

### DIFF
--- a/dist/react-quill.js
+++ b/dist/react-quill.js
@@ -74,18 +74,18 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	
+
 	var React = __webpack_require__(/*! react */ 2),
 		QuillToolbar = __webpack_require__(/*! ./toolbar */ 3),
 		QuillMixin = __webpack_require__(/*! ./mixin */ 4),
 		T = React.PropTypes;
-	
+
 	// Support React 0.11 and 0.12
 	// FIXME: Remove with React 0.13
 	if (React.createFactory) {
 		QuillToolbar = React.createFactory(QuillToolbar);
 	}
-	
+
 	// Support React 0.12 and 0.13+
 	// FIXME: Remove with React 0.13
 	if (React.cloneElement) {
@@ -95,13 +95,13 @@ return /******/ (function(modules) { // webpackBootstrap
 	} else {
 		throw new Error('React addons are required when using React 0.12 or less.');
 	}
-	
+
 	var QuillComponent = React.createClass({
-	
+
 		displayName: 'Quill',
-	
+
 		mixins: [ QuillMixin ],
-	
+
 		propTypes: {
 			id: T.string,
 			className: T.string,
@@ -121,7 +121,7 @@ return /******/ (function(modules) { // webpackBootstrap
 			onChange: T.func,
 			onChangeSelection: T.func
 		},
-	
+
 		/*
 		Changing one of these props should cause a re-render.
 		*/
@@ -135,7 +135,7 @@ return /******/ (function(modules) { // webpackBootstrap
 			'theme',
 			'pollInterval'
 		],
-	
+
 		getDefaultProps: function() {
 			return {
 				className: '',
@@ -145,7 +145,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				}
 			};
 		},
-	
+
 		/*
 		We consider the component to be controlled if
 		whenever `value` is bein sent in props.
@@ -153,7 +153,7 @@ return /******/ (function(modules) { // webpackBootstrap
 		isControlled: function() {
 			return 'value' in this.props;
 		},
-	
+
 		getInitialState: function() {
 			return {
 				value: this.isControlled()
@@ -161,7 +161,7 @@ return /******/ (function(modules) { // webpackBootstrap
 					: this.props.defaultValue
 			};
 		},
-	
+
 		componentWillReceiveProps: function(nextProps) {
 			var editor = this.state.editor;
 			// Update only if we've been passed a new `value`.
@@ -183,14 +183,14 @@ return /******/ (function(modules) { // webpackBootstrap
 				}
 			}
 		},
-	
+
 		componentDidMount: function() {
 			var editor = this.createEditor(
 				this.getEditorElement(),
 				this.getEditorConfig());
-	
+
 			this.setCustomFormats(editor);
-	
+
 			// NOTE: Custom formats will be stripped when creating
 			//       the editor, since they are not present there yet.
 			//       Therefore, we re-set the contents from the props
@@ -198,13 +198,13 @@ return /******/ (function(modules) { // webpackBootstrap
 				this.setEditorContents(editor, this.props.value);
 			}.bind(this));
 		},
-	
+
 		componentWillUnmount: function() {
 			this.destroyEditor(this.state.editor);
 			// NOTE: Don't set the state to null here
 			//       as it would generate a loop.
 		},
-	
+
 		shouldComponentUpdate: function(nextProps, nextState) {
 			// Check if one of the changes should trigger a re-render.
 			for (var i=0; i<this.dirtyProps.length; i++) {
@@ -216,7 +216,7 @@ return /******/ (function(modules) { // webpackBootstrap
 			// Never re-render otherwise.
 			return false;
 		},
-	
+
 		/*
 		If for whatever reason we are rendering again,
 		we should tear down the editor and bring it up
@@ -225,22 +225,22 @@ return /******/ (function(modules) { // webpackBootstrap
 		componentWillUpdate: function() {
 			this.componentWillUnmount();
 		},
-	
+
 		componentDidUpdate: function() {
 			this.componentDidMount();
 		},
-	
+
 		setCustomFormats: function (editor) {
 			if (!this.props.formats) {
 				return;
 			}
-	
+
 			for (var i = 0; i < this.props.formats.length; i++) {
 				var format = this.props.formats[i];
 				editor.addFormat(format.name || format, format);
 			}
 		},
-	
+
 		getEditorConfig: function() {
 			var config = {
 				readOnly:     this.props.readOnly,
@@ -263,19 +263,19 @@ return /******/ (function(modules) { // webpackBootstrap
 			}
 			return config;
 		},
-	
+
 		getEditorElement: function() {
 			return this.refs.editor.getDOMNode();
 		},
-	
+
 		getEditorContents: function() {
 			return this.state.value;
 		},
-	
+
 		getEditorSelection: function() {
 			return this.state.selection;
 		},
-	
+
 		/*
 		Renders either the specified contents, or a default
 		configuration of toolbar and contents area.
@@ -305,7 +305,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				];
 			}
 		},
-	
+
 		render: function() {
 			return React.DOM.div({
 				id: this.props.id,
@@ -318,7 +318,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				this.renderContents()
 			);
 		},
-	
+
 		onEditorChange: function(value, delta, source) {
 			if (value !== this.getEditorContents()) {
 				this.setState({ value: value });
@@ -327,7 +327,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				}
 			}
 		},
-	
+
 		onEditorChangeSelection: function(range, source) {
 			var s = this.getEditorSelection() || {};
 			var r = range || {};
@@ -338,7 +338,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				}
 			}
 		},
-	
+
 		/*
 		Stop change events from the toolbar from
 		bubbling up outside.
@@ -347,9 +347,9 @@ return /******/ (function(modules) { // webpackBootstrap
 			event.preventDefault();
 			event.stopPropagation();
 		}
-	
+
 	});
-	
+
 	module.exports = QuillComponent;
 
 
@@ -370,10 +370,10 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	
+
 	var React = __webpack_require__(/*! react */ 2),
 		T = React.PropTypes;
-	
+
 	var defaultColors = [
 		'rgb(  0,   0,   0)', 'rgb(230,   0,   0)', 'rgb(255, 153,   0)',
 		'rgb(255, 255,   0)', 'rgb(  0, 138,   0)', 'rgb(  0, 102, 204)',
@@ -388,9 +388,9 @@ return /******/ (function(modules) { // webpackBootstrap
 		'rgb(102,  61,   0)', 'rgb(102, 102,   0)', 'rgb(  0,  55,   0)',
 		'rgb(  0,  41, 102)', 'rgb( 61,  20,  10)',
 	].map(function(color){ return { value: color } });
-	
+
 	var defaultItems = [
-	
+
 		{ label:'Formats', type:'group', items: [
 			{ label:'Font', type:'font', items: [
 				{ label:'Sans Serif',  value:'sans-serif' },
@@ -412,7 +412,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				{ label:'', value:'justify' }
 			]}
 		]},
-	
+
 		{ label:'Text', type:'group', items: [
 			{ type:'bold', label:'Bold' },
 			{ type:'italic', label:'Italic' },
@@ -424,38 +424,38 @@ return /******/ (function(modules) { // webpackBootstrap
 			{ type:'separator' },
 			{ type:'link', label:'Link' }
 		]},
-	
+
 		{ label:'Blocks', type:'group', items: [
 			{ type:'bullet', label:'Bullet' },
 			{ type:'separator' },
 			{ type:'list', label:'List' }
 		]}
-	
+
 	];
-	
+
 	var QuillToolbar = React.createClass({
-	
+
 		displayName: 'Quill Toolbar',
-	
+
 		propTypes: {
 			id:        T.string,
 			className: T.string,
 			items:     T.array
 		},
-	
+
 		getDefaultProps: function(){
 			return {
 				items: defaultItems
 			};
 		},
-	
+
 		renderSeparator: function(key) {
 			return React.DOM.span({
 				key: key,
 				className:'ql-format-separator'
 			});
 		},
-	
+
 		renderGroup: function(item, key) {
 			return React.DOM.span({
 				key: item.label || key,
@@ -463,7 +463,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				item.items.map(this.renderItem)
 			);
 		},
-	
+
 		renderChoiceItem: function(item, key) {
 			return React.DOM.option({
 				key: item.label || item.value || key,
@@ -471,7 +471,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				item.label
 			);
 		},
-	
+
 		renderChoices: function(item, key) {
 			return React.DOM.select({
 				key: item.label || key,
@@ -479,7 +479,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				item.items.map(this.renderChoiceItem)
 			);
 		},
-	
+
 		renderAction: function(item, key) {
 			return React.DOM.span({
 				key: item.label || item.value || key,
@@ -487,7 +487,7 @@ return /******/ (function(modules) { // webpackBootstrap
 				title: item.label }
 			);
 		},
-	
+
 		renderItem: function(item, key) {
 			switch (item.type) {
 				case 'separator':
@@ -504,11 +504,11 @@ return /******/ (function(modules) { // webpackBootstrap
 					return this.renderAction(item, key);
 			}
 		},
-	
+
 		getClassName: function() {
 			return 'quill-toolbar ' + (this.props.className||'');
 		},
-	
+
 		render: function() {
 			var children = this.props.items.map(this.renderItem);
 			var html = children.map(React.renderToStaticMarkup).join('');
@@ -517,9 +517,9 @@ return /******/ (function(modules) { // webpackBootstrap
 				dangerouslySetInnerHTML: { __html:html }
 			});
 		}
-	
+
 	});
-	
+
 	module.exports = QuillToolbar;
 	QuillToolbar.defaultItems = defaultItems;
 	QuillToolbar.defaultColors = defaultColors;
@@ -532,11 +532,11 @@ return /******/ (function(modules) { // webpackBootstrap
 /***/ function(module, exports, __webpack_require__) {
 
 	'use strict';
-	
+
 	var Quill = __webpack_require__(/*! quill */ 5);
-	
+
 	var QuillMixin = {
-	
+
 		/**
 		Creates an editor on the given element. The editor will
 		be passed the configuration, have its events bound,
@@ -546,30 +546,30 @@ return /******/ (function(modules) { // webpackBootstrap
 			this.hookEditor(editor);
 			return editor;
 		},
-	
+
 		hookEditor: function(editor) {
 			editor.on('text-change', function(delta, source) {
 				if (this.onEditorChange) {
-					this.onEditorChange(editor.getHTML(), delta, source);
+					this.onEditorChange(editor.getHTML(), editor.getText(), delta, source);
 				}
 			}.bind(this));
-	
+
 			editor.on('selection-change', function(range, source) {
 				if (this.onEditorChangeSelection) {
 					this.onEditorChangeSelection(range, source);
 				}
 			}.bind(this));
 		},
-	
+
 		destroyEditor: function(editor) {
 			editor.destroy();
 		},
-	
+
 		setEditorReadOnly: function(editor, value) {
 			value? editor.editor.disable()
 			     : editor.editor.enable();
 		},
-	
+
 		/*
 		Replace the contents of the editor, but keep
 		the previous selection hanging around so that
@@ -580,7 +580,7 @@ return /******/ (function(modules) { // webpackBootstrap
 			editor.setHTML(value);
 			if (sel) this.setEditorSelection(editor, sel);
 		},
-	
+
 		setEditorSelection: function(editor, range) {
 			if (range) {
 				// Validate bounds before applying.
@@ -590,9 +590,9 @@ return /******/ (function(modules) { // webpackBootstrap
 			}
 			editor.setSelection(range);
 		}
-	
+
 	};
-	
+
 	module.exports = QuillMixin;
 
 /***/ },

--- a/dist/react-quill.js
+++ b/dist/react-quill.js
@@ -550,7 +550,7 @@ return /******/ (function(modules) { // webpackBootstrap
 		hookEditor: function(editor) {
 			editor.on('text-change', function(delta, source) {
 				if (this.onEditorChange) {
-					this.onEditorChange(editor.getHTML(), editor.getText(), delta, source);
+					this.onEditorChange(editor, delta, source);
 				}
 			}.bind(this));
 


### PR DESCRIPTION
The Quill API has a variety of useful functions.  Currently the one I need access to is `getText`.
http://quilljs.com/docs/api/#quillprototypegettext

I added this function to `hookEditor` and tested it locally to ensure that it returns the desired values.

It also appears as though the editor I use (Atom) is automatically deleting tabs on empty lines.  Please let me know if this is a problem, but deleting these seems to be better styling.

@zenoamaro can you merge this when you get a chance?