### PR TITLE
Adding ability to specify children prop for custom toolbar item labels

### DIFF
--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -113,7 +113,8 @@ var QuillToolbar = React.createClass({
 		return React.DOM.span({
 			key: item.label || item.value || key,
 			className: 'ql-format-button ql-'+item.type,
-			title: item.label }
+			title: item.label },
+			item.children
 		);
 	},
 


### PR DESCRIPTION
Currently, it's not possible to add custom labels to the toolbar items. This pull request lets you specify `children` as a property for each item which gets passed as the children argument to `React.DOM.span`. In our case, we need to use our own icons from an `<Icon />` component.