### PR TITLE
Added check for editor being defined in componentWillReceiveProps.

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -89,22 +89,28 @@ var QuillComponent = React.createClass({
 
 	componentWillReceiveProps: function(nextProps) {
 		var editor = this.state.editor;
-		// Update only if we've been passed a new `value`.
-		// This leaves components using `defaultValue` alone.
-		if ('value' in nextProps) {
-			// NOTE: Seeing that Quill is missing a way to prevent
-			//       edits, we have to settle for a hybrid between
-			//       controlled and uncontrolled mode. We can't prevent
-			//       the change, but we'll still override content
-			//       whenever `value` differs from current state.
-			if (nextProps.value !== this.getEditorContents()) {
-				this.setEditorContents(editor, nextProps.value);
+		// If the component is unmounted and mounted too quickly
+		// an error is thrown in setEditorContents since editor is
+		// still undefined. Must check if editor is undefined
+		// before performing this call.
+		if (editor) {
+			// Update only if we've been passed a new `value`.
+			// This leaves components using `defaultValue` alone.
+			if ('value' in nextProps) {
+				// NOTE: Seeing that Quill is missing a way to prevent
+				//       edits, we have to settle for a hybrid between
+				//       controlled and uncontrolled mode. We can't prevent
+				//       the change, but we'll still override content
+				//       whenever `value` differs from current state.
+				if (nextProps.value !== this.getEditorContents()) {
+					this.setEditorContents(editor, nextProps.value);
+				}
 			}
-		}
-		// We can update readOnly state in-place.
-		if ('readOnly' in nextProps) {
-			if (nextProps.readOnly !== this.props.readOnly) {
-				this.setEditorReadOnly(editor, nextProps.readOnly);
+			// We can update readOnly state in-place.
+			if ('readOnly' in nextProps) {
+				if (nextProps.readOnly !== this.props.readOnly) {
+					this.setEditorReadOnly(editor, nextProps.readOnly);
+				}
 			}
 		}
 	},


### PR DESCRIPTION
If editor was undefined, it was throwing an error in setEditorContents.