### PR TITLE
Add focus/blur methods on the editor node. Fixes #25.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ Quick start
 
 API reference
 -------------
-`ReactQuill` accepts a few props:
+
+### Props
 
 `id`
 : ID to be applied to the DOM element.
@@ -171,7 +172,7 @@ API reference
 : Called back with the new selected range, or null when unfocused.
 
 `onKeyPress(event)`
-: Called after a key has been pressed and released. 
+: Called after a key has been pressed and released.
 : Note that, like its native counterpart, this won't be called for special keys such as <kbd>shift</kbd> or <kbd>enter</kbd>. If you need those, hook onto `onKeyDown` or `onKeyUp`.
 
 `onKeyDown(event)`
@@ -180,6 +181,17 @@ API reference
 
 `onKeyUp(event)`
 : Called after a key has been released.
+
+
+### Methods
+
+If you have [a ref to a ReactQuill node](https://facebook.github.io/react/docs/more-about-refs.html), you will be able to invoke the following methods:
+
+`focus()`
+: Focuses the editor.
+
+`blur()`
+: Removes focus from the editor.
 
 
 Building and testing

--- a/src/component.js
+++ b/src/component.js
@@ -264,6 +264,14 @@ var QuillComponent = React.createClass({
 		}
 	},
 
+	focus: function() {
+		this.state.editor.focus();
+	},
+
+	blur: function() {
+		this.setEditorSelection(this.state.editor, null);
+	},
+
 	/*
 	Stop change events from the toolbar from
 	bubbling up outside.


### PR DESCRIPTION
This PR adds two methods on ReactQuill nodes providing a simple imperative API over focusing:

- `focus()`: Focuses the editor.

- `blur()`: Removes focus from the editor.

To be able to call them, first [take a ref] to the editor, then invoke them on that ref:

~~~jsx
render() {
    return (
        <ReactQuill … ref="editor"/>
    );
}
componentDidMount() {
    this.refs.editor.focus();
}
~~~

Note that the ref will only be available while the component is mounted.

[take a ref]: https://facebook.github.io/react/docs/more-about-refs.html