### PR TITLE
add tooltips for the choices in toolbar

### DIFF
--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -104,6 +104,7 @@ var QuillToolbar = React.createClass({
 	renderChoices: function(item, key) {
 		return React.DOM.select({
 			key: item.label || key,
+			title: item.label,
 			className: 'ql-'+item.type },
 			item.items.map(this.renderChoiceItem)
 		);


### PR DESCRIPTION
The choices in the toolbar are missing the hover tooltips. The change is fixing this issue.