### PR TITLE
Adding image-tooltip to modules.

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -66,7 +66,8 @@ var QuillComponent = React.createClass({
 			className: '',
 			theme: 'base',
 			modules: {
-				'link-tooltip': true
+				'link-tooltip': true,
+				'image-tooltip': true
 			}
 		};
 	},


### PR DESCRIPTION
Just a quick fix before proper fix later to enable image-tooltip by default. As of 0.3.0 we can't do anything to add image-tooltip (not the icon, it's doable via editing toolbar items).