### PR TITLE
Exposed Quill

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,3 +5,4 @@ https://github.com/zenoamaro/react-quill
 module.exports = require('./component');
 module.exports.Mixin = require('./mixin');
 module.exports.Toolbar = require('./toolbar');
+module.exports.Quill = require('quill');


### PR DESCRIPTION
There is no way to access Quill directly, and having this possibility allows for unlimited modifications/adding modules to editor. react-quill API doesn't allow to ex. create new module, and this can be a solution (for now at least).

```
var ReactQuill = require('react-quill');

ReactQuill.Quill.registerModule('my-image-tooltip', function (quill, options) {
    // ...
});
```