### PR TITLE
Fix renderChoices of toolbar

### DIFF
--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -101,17 +101,23 @@ var QuillToolbar = React.createClass({
 	renderChoiceItem: function(item, key) {
 		return React.DOM.option({
 			key: item.label || item.value || key,
-			value:item.value,
-			selected:item.selected },
+			value:item.value },
 			item.label
 		);
 	},
 
 	renderChoices: function(item, key) {
-		return React.DOM.select({
+		var attrs = {
 			key: item.label || key,
 			title: item.label,
-			className: 'ql-'+item.type },
+			className: 'ql-'+item.type
+		};
+		item.items.map(function(item) {
+			if (item.selected) {
+				attrs.defaultValue = item.value;
+			}
+		})
+		return React.DOM.select(attrs,
 			item.items.map(this.renderChoiceItem)
 		);
 	},

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -112,14 +112,14 @@ var QuillToolbar = React.createClass({
 			title: item.label,
 			className: 'ql-'+item.type
 		};
-		item.items.map(function(item) {
+		var self = this;
+		var choiceItems = item.items.map(function(item, key) {
 			if (item.selected) {
 				attrs.defaultValue = item.value;
 			}
+			return self.renderChoiceItem(item, key);
 		})
-		return React.DOM.select(attrs,
-			item.items.map(this.renderChoiceItem)
-		);
+		return React.DOM.select(attrs, choiceItems);
 	},
 
 	renderAction: function(item, key) {


### PR DESCRIPTION
The current renderChoices raises warning:

> Warning: Use the `defaultValue` or `value` props on \<select\> instead of setting `selected` on \<option\>.

It can be seen in Console of "https://zenoamaro.github.io/react-quill/".

This commit solved the issue with not very elegant code. If it's OK to change the format of toolbar ```defaultItems``` a little bit (add "defaultValue" attribute to indicate selected item, instead of "selected:true"), the code could be simpler.