### PR TITLE
Expose Quill in exports

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ var styleOptions = { scope: Parchment.Scope.INLINE };
 Quill.register(new QuillStyle('size', 'font-size', styleOptions), true);
 Quill.register(new QuillStyle('font', 'font-family', styleOptions), true);
 
-module.exports.Quill = Quill;
 module.exports = require('./component');
+module.exports.Quill = Quill;
 module.exports.Mixin = require('./mixin');
 module.exports.Toolbar = require('./toolbar');


### PR DESCRIPTION
Hey friends,

I may be misunderstanding what's going on, but I would expect that `Quill` should be included in the exports so that those using the library can customize parchment blots and things like that.

Perhaps it's expected that `Quill` is accessible via a global like `window.Quill`, but, IMHO, that shouldn't be assumed.