### PR TITLE
Strict rules for custom editing areas

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,12 +338,13 @@ class MyComponent extends React.Component {
 
 ### Mixin
 
-The module exports a mixin which can be used to create custom editor components. (Note that mixins will be deprecated in a future version of React).
+The module exports a mixin which can be used to create custom editor components. (Note that mixins will be deprecated in a future version of React). 
 
 <details>
+The ReactQuill default component is built using the mixin. See [component.js](src/component.js) for source.
+
 ```jsx
 import {Mixin} from 'react-quill'
-The ReactQuill default component is built using the mixin. See [component.js](src/component.js) for source.
 
 var MyComponent = React.createClass({
   mixins: [ ReactQuill.Mixin ],
@@ -501,7 +502,7 @@ This property previously set the frequency with which Quill polled the DOM for c
 : Selector or DOM element used by Quill to constrain position of popups. Defaults to `document.body`.
 
 `children`
-: A single React element that will be used as the editing area for Quill in place of the default, which is a `<div>`. Note that you cannot use a `<textarea>`, as it is not a supported target. Note also that updating children is costly, as it will cause the Quill editor to be recreated. Use value if you want to control the html contents of the editor.
+: A single React element that will be used as the editing area for Quill in place of the default, which is a `<div>`. Note that you cannot use a `<textarea>`, as it is not a supported target. Note also that updating children is costly, as it will cause the Quill editor to be recreated. Set the `value` prop if you want to control the html contents of the editor.
 
 `onChange(content, delta, source, editor)`
 : Called back with the new contents of the editor after change. It will be passed the HTML contents of the editor, a delta object expressing the change-set itself, the source of the change, and finally a read-only proxy to editor accessors such as `getText()`.

--- a/README.md
+++ b/README.md
@@ -316,6 +316,26 @@ class MyComponent extends React.Component {
 ```
 </details>
 
+### Custom editing area
+
+If you instantiate ReactQuill without children, it will create a `<div>` for you, to be used as the editing area for Quill. If you prefer, you can specify your own element for ReactQuill to use.
+
+<details>
+```jsx
+class MyComponent extends React.Component {
+
+  render() {
+    return (
+      <ReactQuill>
+        <div className="my-editing-area"/>
+      </ReactQuill>
+    );
+  }
+
+});
+```
+</details>
+
 ### Mixin
 
 The module exports a mixin which can be used to create custom editor components. (Note that mixins will be deprecated in a future version of React).
@@ -323,6 +343,7 @@ The module exports a mixin which can be used to create custom editor components.
 <details>
 ```jsx
 import {Mixin} from 'react-quill'
+The ReactQuill default component is built using the mixin. See [component.js](src/component.js) for source.
 
 var MyComponent = React.createClass({
   mixins: [ ReactQuill.Mixin ],
@@ -343,7 +364,6 @@ var MyComponent = React.createClass({
 
 });
 ```
-The ReactQuill default component is built using the mixin. See [component.js](src/component.js) for source.
 </details>
 
 ## Upgrading to React-Quill v1.0.0
@@ -372,7 +392,7 @@ Previously, toolbar properties could be set by passing a `toolbar` prop to React
   />
 ~~~
 
-If you provided your own HTML toolbar component, you can still do the same:
+If you used to provide your own HTML toolbar component, you can still do the same:
 
 ~~~diff
 + modules: {
@@ -384,6 +404,8 @@ If you provided your own HTML toolbar component, you can still do the same:
 +   modules={this.modules}
   />
 ~~~
+
+Note that it is not possible to pass a toolbar component as a child to ReactQuill anymore.
 
 Previously, React Quill would create a custom HTML toolbar for you if you passed a configuration object as the `toolbar` prop. This will not happen anymore. You can still create a `ReactQuill.Toolbar` explicitly:
 
@@ -477,6 +499,9 @@ This property previously set the frequency with which Quill polled the DOM for c
 
 `bounds`
 : Selector or DOM element used by Quill to constrain position of popups. Defaults to `document.body`.
+
+`children`
+: A single React element that will be used as the editing area for Quill in place of the default, which is a `<div>`. Note that you cannot use a `<textarea>`, as it is not a supported target. Note also that updating children is costly, as it will cause the Quill editor to be recreated. Use value if you want to control the html contents of the editor.
 
 `onChange(content, delta, source, editor)`
 : Called back with the new contents of the editor after change. It will be passed the HTML contents of the editor, a delta object expressing the change-set itself, the source of the change, and finally a read-only proxy to editor accessors such as `getText()`.

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ var MyComponent = React.createClass({
 
   componentDidMount: function() {
     var editor = this.createEditor(
-      this.getEditorElement(),
+      this.getEditingArea(),
       this.getEditorConfig()
     );
     this.setState({ editor:editor });

--- a/src/component.js
+++ b/src/component.js
@@ -75,6 +75,20 @@ var QuillComponent = React.createClass({
 				'You can safely remove it from your props.' +
 				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v1-0-0'
 			);
+		},
+
+		children: function(props) {
+			var isNotASingleElement = React.PropTypes.element.apply(this, arguments);
+			if (isNotASingleElement) return new Error(
+				'The Quill editing area can only be composed of a single React element.'
+			);
+
+			if (React.Children.count(props.children)) {
+				var child = React.Children.only(props.children);
+				if (child.type === 'textarea') return new Error(
+					'Quill does not support editing on a <textarea>. Use a <div> instead.'
+				);
+			}
 		}
 	},
 		

--- a/src/component.js
+++ b/src/component.js
@@ -78,6 +78,7 @@ var QuillComponent = React.createClass({
 		},
 
 		children: function(props) {
+			// Validate that the editor has only one child element and it is not a <textarea>
 			var isNotASingleElement = React.PropTypes.element.apply(this, arguments);
 			if (isNotASingleElement) return new Error(
 				'The Quill editing area can only be composed of a single React element.'

--- a/src/component.js
+++ b/src/component.js
@@ -58,14 +58,14 @@ var QuillComponent = React.createClass({
 
 			if (isNotArrayOfString) return new Error(
 				'You cannot specify custom `formats` anymore. Use Parchment instead.  ' +
-				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v1-0-0'
+				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v100.'
 			);
 		},
 
 		styles: function(props) {
 			if ('styles' in props) return new Error(
 				'The `styles` prop has been deprecated. Use custom stylesheets instead. ' +
-				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v1-0-0'
+				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v100.'
 			);
 		},
 
@@ -73,7 +73,7 @@ var QuillComponent = React.createClass({
 			if ('pollInterval' in props) return new Error(
 				'The `pollInterval` property does not have any effect anymore. ' +
 				'You can safely remove it from your props.' +
-				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v1-0-0'
+				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v100.'
 			);
 		},
 

--- a/src/component.js
+++ b/src/component.js
@@ -103,6 +103,7 @@ var QuillComponent = React.createClass({
 		'formats',
 		'bounds',
 		'theme',
+		'children',
 	],
 
 	getDefaultProps: function() {

--- a/src/component.js
+++ b/src/component.js
@@ -160,7 +160,7 @@ var QuillComponent = React.createClass({
 
 	componentDidMount: function() {
 		var editor = this.createEditor(
-			this.getEditorElement(),
+			this.getEditingArea(),
 			this.getEditorConfig()
 		);
 		this.editor = editor;
@@ -209,9 +209,8 @@ var QuillComponent = React.createClass({
 		return this.editor;
 	},
 
-	getEditorElement: function () {
-		// TODO: replace string ref with callback ref
-		return ReactDOM.findDOMNode(this.refs.editor);
+	getEditingArea: function () {
+		return ReactDOM.findDOMNode(this.editingArea);
 	},
 
 	getEditorContents: function() {
@@ -226,10 +225,11 @@ var QuillComponent = React.createClass({
 	Renders an editor area, unless it has been provided one to clone.
 	*/
 	renderEditingArea: function() {
+		var self = this;
 		var children = this.props.children;
 
 		var properties = {
-			ref: 'editor',
+			ref: function(element) { self.editingArea = element },
 			dangerouslySetInnerHTML: { __html:this.getEditorContents() }
 		};
 

--- a/src/component.js
+++ b/src/component.js
@@ -208,26 +208,22 @@ var QuillComponent = React.createClass({
 	},
 
 	/*
-	Renders an editor element, unless it has been provided one to clone.
+	Renders an editor area, unless it has been provided one to clone.
 	*/
-	renderContents: function() {
-		var contents = [];
-		var children = React.Children.map(
-			this.props.children,
-			function(c) { return React.cloneElement(c, {ref: c.ref}); }
-		);
+	renderEditingArea: function() {
+		var children = this.props.children;
 
-		var editor = find(children, function(child) {
-			return child.ref === 'editor';
-		});
-		contents.push(editor || React.DOM.div({
-			key: 'editor-' + Math.random(),
+		var properties = {
 			ref: 'editor',
-			className: 'quill-contents',
 			dangerouslySetInnerHTML: { __html:this.getEditorContents() }
-		}));
+		};
 
-		return contents;
+		if (React.Children.count(children) === 0) {
+			return React.DOM.div(properties);
+		}
+
+		var editor = React.Children.only(children);
+		return React.cloneElement(editor, properties);
 	},
 
 	render: function() {
@@ -238,7 +234,7 @@ var QuillComponent = React.createClass({
 			onKeyPress: this.props.onKeyPress,
 			onKeyDown: this.props.onKeyDown,
 			onKeyUp: this.props.onKeyUp },
-			this.renderContents()
+			this.renderEditingArea()
 		);
 	},
 

--- a/test/index.js
+++ b/test/index.js
@@ -114,6 +114,13 @@ describe('<ReactQuill />', function() {
     expect(wrapper.getNode().getEditorContents()).to.equal(value)
   })
 
+  it('uses a custom editing area if provided', () => {
+    const editingArea = React.DOM.div({id:'venus'});
+    const wrapper = mount(ReactQuillNode({}, editingArea));
+    const quill = wrapper.getNode().getEditor();
+    expect(wrapper.getDOMNode().querySelector('div#venus')).not.to.be.null;
+  })
+
   /**
    * This can't be tested with the current state of JSDOM. 
    * The selection functions have been shimmed in this test suite, 
@@ -145,23 +152,15 @@ describe('<ReactQuill />', function() {
 
 });
 
-function ReactQuillNode(props, html) {
-  html = html || '';
-  props = props || {};
-  Object.assign(props, {
+function ReactQuillNode(props, children) {
+  props = Object.assign({
     modules: {'toolbar': ['underline', 'bold', 'italic']},
     formats: ['underline', 'bold', 'italic']
-  })
+  }, props);
+  
   return React.createElement(
     ReactQuill,
     props,
-    [
-      React.DOM.div({
-        key: "editor",
-        ref: "editor",
-        className: "quill-contents",
-        dangerouslySetInnerHTML: { __html: html }
-      }),
-    ]
+    children
   );
 }


### PR DESCRIPTION
This will make ReactQuill be stricter in what it accepts as children.

Previously, a toolbar and an editor area would be accepted as children, distinguished by string ref, and hooked to the Quill instance.

Now, ReactQuill will only accept a single React element as a child, which will be directly connected to the editor without ref mangling. This area cannot be a `<textarea>`, something which the user is also warned of.

In theory, this would allow getting rid of the outer wrapper. In practice, however, I think it's useful enough to be worth keeping.

#### Benefits:
- User is warned about improper usage
- No more lookup by ref, which was a hack
- Parent refs are also maintained now, because we use function refs

#### Downsides:
- Anybody relying on the ability to provide arbitrary children to ReactQuill will not be able to do this anymore. This was not part of the published interface, however