### PR TITLE
Cleaner rerendering

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -19,7 +19,7 @@
 	"strict": true,
 	"maxdepth": 3,
 	"maxparams": 4,
-	"maxcomplexity": 6,
+	"maxcomplexity": 8,
 	"maxlen": 100,
 	"eqnull": true,
 	"lastsemic": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,12 @@ This release supports Quill v1.0.0+. ⚠️ There are many breaking changes, so 
 - Updated rendering of toolbar actions (@clemmy)
 - Improved toolbar renderChoices implementation (@zhang-z)
 - Fixed use of `defaultValue` in Toolbar selects
+- Fixed bounds validation in setEditorSelection (@wouterh)
+- Exposed Quill in exports (@tdg5)
+- Added unhook function to clean up event listeners on unmount (@alexkrolick, @jrmmnr)
+- Fixed documentation typos (@l3kn)
+- Started testing with Enzyme (@alexkrolick)
+- Fixed issue where changing props caused re-render artifacts (#147)
 
 v0.4.1
 ------

--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Thanks to @clemmy and @alexkrolick for landing this much-awaited change. There a
  
 ---
 
-🎧 **Latest published package version: `v1.0.0-beta-3`**  
+🎧 **Latest published package version: `v1.0.0-beta-4`**  
 Follow React Quill's development on the beta channel leading to `v1.0.0`.  
-`npm install react-quill@v1.0.0-beta-3`
+`npm install react-quill@v1.0.0-beta-4`
  
 ---
 
@@ -635,6 +635,7 @@ This release adds support for Quill v1.0.0+. ⚠️ There are many breaking chan
 - Added unhook function to clean up event listeners on unmount (@alexkrolick, @jrmmnr)
 - Fixed documentation typos (@l3kn)
 - Started testing with Enzyme (@alexkrolick)
+- Fixed issue where changing props caused re-render artifacts (#147)
 
 #### v0.4.1
 - Added contents of `dist` to NPM package.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-quill",
-  "version": "1.0.0-beta-3",
+  "version": "1.0.0-beta-4",
   "description": "The Quill rich-text editor as a React component.",
   "author": "zenoamaro <zenoamaro@gmail.com>",
   "homepage": "https://github.com/zenoamaro/react-quill",

--- a/src/component.js
+++ b/src/component.js
@@ -183,10 +183,16 @@ var QuillComponent = React.createClass({
 			this.getEditingArea(),
 			this.getEditorConfig()
 		);
-		if (this.state.value) this.setEditorContents(
-			this.editor,
-			this.state.value
-		);
+		if (this.quillDelta) {
+			this.editor.setContents(this.quillDelta);
+			this.editor.setSelection(this.quillSelection);		
+			this.editor.focus();
+			return;
+		}
+		if (this.state.value) {
+			this.setEditorContents(this.editor, this.state.value);
+			return;
+		}
 	},
 
 	componentWillUnmount: function() {
@@ -270,7 +276,11 @@ var QuillComponent = React.createClass({
 	to be cleaned up and re-rendered from scratch.
 	*/
 	regenerate: function() {
-		this.setState({generation: this.state.generation + 1});
+		this.quillDelta = this.editor.getContents();
+		this.quillSelection = this.editor.getSelection();
+		this.setState({
+			generation: this.state.generation + 1,
+		});
 	},
 
 	/*

--- a/src/component.js
+++ b/src/component.js
@@ -42,14 +42,14 @@ var QuillComponent = React.createClass({
 			) return new Error(
 				'Since v1.0.0, React Quill will not create a custom toolbar for you ' +
 				'anymore. Create a toolbar explictly, or let Quill create one. ' +
-				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v1-0-0'
+				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v100'
 			);
 		},
 
 		toolbar: function(props) {
 			if ('toolbar' in props) return new Error(
 				'The `toolbar` prop has been deprecated. Use `modules.toolbar` instead. ' +
-				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v1-0-0'
+				'See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v100'
 			);
 		},
 

--- a/src/component.js
+++ b/src/component.js
@@ -183,10 +183,12 @@ var QuillComponent = React.createClass({
 			this.getEditingArea(),
 			this.getEditorConfig()
 		);
+		// Restore editor from Quill's native formats in regeneration scenario
 		if (this.quillDelta) {
 			this.editor.setContents(this.quillDelta);
 			this.editor.setSelection(this.quillSelection);		
 			this.editor.focus();
+			this.quillDelta = this.quillSelection = null;
 			return;
 		}
 		if (this.state.value) {
@@ -276,6 +278,7 @@ var QuillComponent = React.createClass({
 	to be cleaned up and re-rendered from scratch.
 	*/
 	regenerate: function() {
+		// Cache selection and contents in Quill's native format to be restored later
 		this.quillDelta = this.editor.getContents();
 		this.quillSelection = this.editor.getSelection();
 		this.setState({

--- a/src/component.js
+++ b/src/component.js
@@ -150,29 +150,30 @@ var QuillComponent = React.createClass({
 		}
 
 		var editor = this.editor;
-		
+
 		// If the component is unmounted and mounted too quickly
 		// an error is thrown in setEditorContents since editor is
 		// still undefined. Must check if editor is undefined
 		// before performing this call.
-		if (editor) {
-			// Update only if we've been passed a new `value`.
-			// This leaves components using `defaultValue` alone.
-			if ('value' in nextProps) {
-				// NOTE: Seeing that Quill is missing a way to prevent
-				//       edits, we have to settle for a hybrid between
-				//       controlled and uncontrolled mode. We can't prevent
-				//       the change, but we'll still override content
-				//       whenever `value` differs from current state.
-				if (nextProps.value !== this.getEditorContents()) {
-					this.setEditorContents(editor, nextProps.value);
-				}
+		if (!editor) return;
+		
+		// Update only if we've been passed a new `value`.
+		// This leaves components using `defaultValue` alone.
+		if ('value' in nextProps) {
+			// NOTE: Seeing that Quill is missing a way to prevent
+			//       edits, we have to settle for a hybrid between
+			//       controlled and uncontrolled mode. We can't prevent
+			//       the change, but we'll still override content
+			//       whenever `value` differs from current state.
+			if (nextProps.value !== this.getEditorContents()) {
+				this.setEditorContents(editor, nextProps.value);
 			}
-			// We can update readOnly state in-place.
-			if ('readOnly' in nextProps) {
-				if (nextProps.readOnly !== this.props.readOnly) {
-					this.setEditorReadOnly(editor, nextProps.readOnly);
-				}
+		}
+		
+		// We can update readOnly state in-place.
+		if ('readOnly' in nextProps) {
+			if (nextProps.readOnly !== this.props.readOnly) {
+				this.setEditorReadOnly(editor, nextProps.readOnly);
 			}
 		}
 	},
@@ -189,7 +190,7 @@ var QuillComponent = React.createClass({
 	},
 
 	componentWillUnmount: function() {
-		var editor; if (editor = this.getEditor()) {
+		var editor; if ((editor = this.getEditor())) {
 			this.unhookEditor(editor);
 			this.editor = null;
 		}


### PR DESCRIPTION
Concept of `cleanProps` allows performing regular updates that affect DOM nodes.

Keyed elements and controlled lifecycle avoid breaking Quill when re-rendering.

Optimized comparisons for value prop updates after content changes.

Should fix #147 and others.