### PR TITLE
update README.md to reference core.css instead of base.css

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ And then link the appropriate stylesheet (only link the CSS for the themes you w
 ```html
 <link rel="stylesheet" href="node_modules/react-quill/dist/quill.snow.css">
 <link rel="stylesheet" href="node_modules/react-quill/dist/quill.bubble.css">
-<link rel="stylesheet" href="node_modules/react-quill/dist/quill.base.css">
+<link rel="stylesheet" href="node_modules/react-quill/dist/quill.core.css">
 ```
 
 This may vary depending how application is structured, directories or otherwise. For example, if you use a CSS pre-processor like SASS, you may want to import that stylesheet inside your own.


### PR DESCRIPTION
It seems like `node_modules/react-quill/dist/quill.base.css` got renamed to `quill.core.css` somewhere along the line and the `README.md` wasn't updated.

Thanks for the hard work `react-quill` team!