### PR TITLE
Update react peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "quill": "^1.2.0"
   },
   "peerDependencies": {
-    "react": ">=0.14.0"
+    "react": "^0.14.0 || ^15.0.0-0"
   },
   "devDependencies": {
     "blanket": "^1.1.6",


### PR DESCRIPTION
Without this change, when `react-quill` is installed in a project which uses React 15.x, it would install its own React 0.14, nested in `myproject/node_modules/react-quill/node_modules/react`.

With my PR, `react-quill` uses the version of React already installed. It saved me a few KB.