### PR TITLE
Adds focus and blur events. Closes #110

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,6 +600,12 @@ import ReactQuill, { Quill, Mixin, Toolbar } from 'react-quill'; // ES6
 `onChangeSelection(range, source, editor)`
 : Called back with the new selected range, or null when unfocused. It will be passed the selection range, the source of the change, and finally a read-only proxy to editor accessors such as `getBounds()`.
 
+`onFocus(range, source, editor)`
+: Called when the editor becomes focused. It will receive the new selection range.
+
+`onBlur(previousRange, source, editor)`
+: Called when the editor loses focus. It will receive the selection range it had right before losing focus.
+
 `onKeyPress(event)`
 : Called after a key has been pressed and released.
 : Note that, like its native counterpart, this won't be called for special keys such as <kbd>shift</kbd> or <kbd>enter</kbd>. If you need those, hook onto `onKeyDown` or `onKeyUp`.

--- a/demo/index.js
+++ b/demo/index.js
@@ -47,6 +47,22 @@ var Editor = React.createClass({
 		});
 	},
 
+	onEditorFocus: function(range, source) {
+		this.setState({
+			events: [
+				'focus('+this.formatRange(range)+')'
+			].concat(this.state.events)
+		});
+	},
+
+	onEditorBlur: function(previousRange, source) {
+		this.setState({
+			events: [
+				'blur('+this.formatRange(previousRange)+')'
+			].concat(this.state.events)
+		});
+	},
+
 	onToggle: function() {
 		this.setState({ enabled: !this.state.enabled });
 	},
@@ -66,7 +82,9 @@ var Editor = React.createClass({
 					value: this.state.value,
 					readOnly: this.state.readOnly,
 					onChange: this.onEditorChange,
-					onChangeSelection: this.onEditorChangeSelection
+					onChangeSelection: this.onEditorChangeSelection,
+					onFocus: this.onEditorFocus,
+					onBlur: this.onEditorBlur,
 				})
 			)
 		);

--- a/src/component.js
+++ b/src/component.js
@@ -27,11 +27,11 @@ var QuillComponent = React.createClass({
 		bounds: T.oneOfType([T.string, T.element]),
 		onChange: T.func,
 		onChangeSelection: T.func,
+		onFocus: T.func,
+		onBlur: T.func,
 		onKeyPress: T.func,
 		onKeyDown: T.func,
 		onKeyUp: T.func,
-		onFocus: T.func,
-		onBlur: T.func,
 
 		modules: function(props) {
 			var isNotObject = T.object.apply(this, arguments);
@@ -116,11 +116,13 @@ var QuillComponent = React.createClass({
 		'style',
 		'placeholder',
 		'tabIndex',
+		'onChange',
+		'onChangeSelection',
+		'onFocus',
+		'onBlur',
 		'onKeyPress',
 		'onKeyDown',
 		'onKeyUp',
-		'onChange',
-		'onChangeSelection',
 	],
 
 	getDefaultProps: function() {

--- a/src/component.js
+++ b/src/component.js
@@ -25,11 +25,13 @@ var QuillComponent = React.createClass({
 		placeholder: T.string,
 		tabIndex: T.number,
 		bounds: T.oneOfType([T.string, T.element]),
+		onChange: T.func,
+		onChangeSelection: T.func,
 		onKeyPress: T.func,
 		onKeyDown: T.func,
 		onKeyUp: T.func,
-		onChange: T.func,
-		onChangeSelection: T.func,
+		onFocus: T.func,
+		onBlur: T.func,
 
 		modules: function(props) {
 			var isNotObject = T.object.apply(this, arguments);
@@ -377,13 +379,19 @@ var QuillComponent = React.createClass({
 	},
 
 	onEditorChangeSelection: function(range, source, editor) {
-		var s = this.getEditorSelection() || {};
-		var r = range || {};
-		if (r.length !== s.length || r.index !== s.index) {
-			this.setState({ selection: range });
-			if (this.props.onChangeSelection) {
-				this.props.onChangeSelection(range, source, editor);
-			}
+		var currentSelection = this.getEditorSelection();
+		var nextSelection = range;
+		if (isEqual(nextSelection, currentSelection)) {
+			return;
+		}
+		this.setState({ selection: range });
+		if (this.props.onChangeSelection) {
+			this.props.onChangeSelection(range, source, editor);
+		}
+		if (this.props.onFocus && !currentSelection && nextSelection) {
+			this.props.onFocus(nextSelection, source, editor);
+		} else if (this.props.onBlur && currentSelection && !nextSelection) {
+			this.props.onBlur(currentSelection, source, editor);
 		}
 	},
 

--- a/src/component.js
+++ b/src/component.js
@@ -380,19 +380,24 @@ var QuillComponent = React.createClass({
 		}
 	},
 
-	onEditorChangeSelection: function(range, source, editor) {
+	onEditorChangeSelection: function(nextSelection, source, editor) {
 		var currentSelection = this.getEditorSelection();
-		var nextSelection = range;
+		var hasGainedFocus = !currentSelection && nextSelection;
+		var hasLostFocus = currentSelection && !nextSelection;
+
 		if (isEqual(nextSelection, currentSelection)) {
 			return;
 		}
+		
 		this.setState({ selection: range });
+		
 		if (this.props.onChangeSelection) {
 			this.props.onChangeSelection(range, source, editor);
 		}
-		if (this.props.onFocus && !currentSelection && nextSelection) {
+
+		if (hasGainedFocus && this.props.onFocus) {
 			this.props.onFocus(nextSelection, source, editor);
-		} else if (this.props.onBlur && currentSelection && !nextSelection) {
+		} else if (hasLostFocus && this.props.onBlur) {
 			this.props.onBlur(currentSelection, source, editor);
 		}
 	},


### PR DESCRIPTION
Adds `onFocus` and `onBlur` event handlers, as shorthands derived from `onChangeSelection`.

They provide the new range, and the previous range, respectively, along with the usual `source` and `editor` arguments.

Should be just a minor bump.