### PR TITLE
Added tabIndex prop for built-in editing area. Closes #232

### DIFF
--- a/README.md
+++ b/README.md
@@ -568,6 +568,9 @@ import ReactQuill, { Quill, Mixin, Toolbar } from 'react-quill'
 `theme`
 : The name of the theme to apply to the editor. Defaults to `snow`, Quill's standard theme. Pass `null` to use the minimal core theme. See the [docs on themes](#theme) for more information on including the required stylesheets.
 
+`tabIndex`
+: The order in which the editor becomes focused, among other controls in the page, during keyboard navigation.
+
 `bounds`
 : Selector or DOM element used by Quill to constrain position of popups. Defaults to `document.body`.
 

--- a/src/component.js
+++ b/src/component.js
@@ -23,6 +23,7 @@ var QuillComponent = React.createClass({
 		value: T.string,
 		defaultValue: T.string,
 		placeholder: T.string,
+		tabIndex: T.number,
 		bounds: T.oneOfType([T.string, T.element]),
 		onKeyPress: T.func,
 		onKeyDown: T.func,
@@ -112,6 +113,7 @@ var QuillComponent = React.createClass({
 		'className',
 		'style',
 		'placeholder',
+		'tabIndex',
 		'onKeyPress',
 		'onKeyDown',
 		'onKeyUp',
@@ -295,6 +297,7 @@ var QuillComponent = React.createClass({
 
 		var properties = {
 			key: this.state.generation,
+			tabIndex: this.props.tabIndex,
 			ref: function(element) { self.editingArea = element },
 		};
 


### PR DESCRIPTION
Adds a `tabIndex` property that is set on the editing area.

It affects both the built-in area and custom-provided one. Maybe it shouldn't affect both. This might be a point of contention. It does not provide anything for the toolbar at the moment.

It should be a minor bump.