### PR TITLE
Add TypeScript type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "main": "lib/index.js",
   "browser": "lib/index.js",
+  "types": "types.d.ts",
   "scripts": {
     "test": "make test",
     "build": "make build",
@@ -43,6 +44,8 @@
     "LICENSE"
   ],
   "dependencies": {
+    "@types/quill": "*",
+    "@types/react": "*",
     "create-react-class": "^15.6.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",

--- a/types.d.ts
+++ b/types.d.ts
@@ -10,7 +10,7 @@ interface ToolbarOptionObject {
     };
 }
 
-export interface QuillModules {
+export interface Modules {
     toolbar: string | ToolbarOptionObject | ToolbarOptionItem[];
 }
 
@@ -22,50 +22,57 @@ export interface UnprivilegedEditor {
     getSelection(focus?: boolean): Quill.RangeStatic;
 }
 
-export interface QuillComponentProps {
-    id: string;
-    className: string;
-    theme: string;
-    style: React.CSSProperties;
-    readOnly: boolean;
-    value: string | Quill.Delta;
-    defaultValue: string | Quill.Delta;
-    placeholder: string;
-    tabIndex: number;
-    bounds: string | HTMLElement;
-    onChange(content: string, delta: Quill.Delta, source: Quill.Sources, editor: UnprivilegedEditor): void;
-    onChangeSelection(range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor): void;
-    onFocus(range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor): void;
-    onBlur(previousRange: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor): void;
-    onKeyPress: React.EventHandler<any>;
-    onKeyDown: React.EventHandler<any>;
-    onKeyUp: React.EventHandler<any>;
-    modules: QuillModules;
-    // toolbar: never;
-    formats: string[];
-    // styles: never;
-    // pollInterval: never;
-    children: React.ReactElement<any>;
+export interface ComponentProps {
+    id?: string;
+    className?: string;
+    theme?: string;
+    style?: React.CSSProperties;
+    readOnly?: boolean;
+    value?: string | Quill.Delta;
+    defaultValue?: string | Quill.Delta;
+    placeholder?: string;
+    tabIndex?: number;
+    bounds?: string | HTMLElement;
+    onChange?: (content: string, delta: Quill.Delta, source: Quill.Sources, editor: UnprivilegedEditor) => void;
+    onChangeSelection?: (range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor) => void;
+    onFocus?: (range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor) => void;
+    onBlur?: (previousRange: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor) => void;
+    onKeyPress?: React.EventHandler<any>;
+    onKeyDown?: React.EventHandler<any>;
+    onKeyUp?: React.EventHandler<any>;
+    formats?: string[];
+    children?: React.ReactElement<any>;
+    modules?: Modules;
+
+    // Deprecated props
+    toolbar?: never;
+    styles?: never;
+    pollInterval?: never;
 }
 
-export default class QuillComponent extends React.Component<QuillComponentProps> {
+export default class Component extends React.Component<ComponentProps> {
     focus(): void;
     blur(): void;
     getEditor(): Quill.Quill;
 }
 
-export interface QuillToolbarItems {}
-
-export interface QuillToolbarProps {
-    id: string;
-    className: string;
-    style: Object;
-    items: any[];
+export interface ToolbarItem {
+    type: string;
+    label?: string;
+    value?: string;
+    items?: ToolbarItem[];
 }
 
-export class QuillToolbar extends React.Component<QuillToolbarProps> {}
+export interface ToolbarProps {
+    id?: string;
+    className?: string;
+    style?: Object;
+    items?: ToolbarItem[];
+}
 
-export interface QuillMixin {
+export class Toolbar extends React.Component<ToolbarProps> {}
+
+export interface Mixin {
     createEditor(element: HTMLElement, config: Quill.QuillOptionsStatic): Quill.Quill;
     hookEditor(editor: Quill.Quill): void;
     unhookEditor(editor: Quill.Quill): void;

--- a/types.d.ts
+++ b/types.d.ts
@@ -21,12 +21,12 @@ export interface Modules {
 }
 
 export interface UnprivilegedEditor {
-	getLength: () => number;
-	getText: () => string;
-	getHTML: () => string;
+	getLength(): number;
+    getText(index?: number, length?: number): string;
+	getHTML(): string;
 	getBounds(index: number, length?: number): Quill.BoundsStatic;
-	getSelection(focus?: boolean): Quill.RangeStatic;
-}
+    getSelection(focus?: boolean): Quill.RangeStatic;
+    getContents(index?: number, length?: number): DeltaStatic;}
 
 export interface ComponentProps {
 	id?: string;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,76 @@
+import * as React from "react";
+import * as Quill from "quill";
+
+type ToolbarOptionItem = string | string[] | Object[];
+
+interface ToolbarOptionObject {
+    container: string;
+    handlers?: {
+        [key: string]: Function;
+    };
+}
+
+export interface QuillModules {
+    toolbar: string | ToolbarOptionObject | ToolbarOptionItem[];
+}
+
+export interface UnprivilegedEditor {
+    getLength: () => number;
+    getText: () => string;
+    getHTML: () => string;
+    getBounds(index: number, length?: number): Quill.BoundsStatic;
+    getSelection(focus?: boolean): Quill.RangeStatic;
+}
+
+export interface QuillComponentProps {
+    id: string;
+    className: string;
+    theme: string;
+    style: React.CSSProperties;
+    readOnly: boolean;
+    value: string | Quill.Delta;
+    defaultValue: string | Quill.Delta;
+    placeholder: string;
+    tabIndex: number;
+    bounds: string | HTMLElement;
+    onChange(content: string, delta: Quill.Delta, source: Quill.Sources, editor: UnprivilegedEditor): void;
+    onChangeSelection(range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor): void;
+    onFocus(range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor): void;
+    onBlur(previousRange: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor): void;
+    onKeyPress: React.EventHandler<any>;
+    onKeyDown: React.EventHandler<any>;
+    onKeyUp: React.EventHandler<any>;
+    modules: QuillModules;
+    // toolbar: never;
+    formats: string[];
+    // styles: never;
+    // pollInterval: never;
+    children: React.ReactElement<any>;
+}
+
+export default class QuillComponent extends React.Component<QuillComponentProps> {
+    focus(): void;
+    blur(): void;
+    getEditor(): Quill.Quill;
+}
+
+export interface QuillToolbarItems {}
+
+export interface QuillToolbarProps {
+    id: string;
+    className: string;
+    style: Object;
+    items: any[];
+}
+
+export class QuillToolbar extends React.Component<QuillToolbarProps> {}
+
+export interface QuillMixin {
+    createEditor(element: HTMLElement, config: Quill.QuillOptionsStatic): Quill.Quill;
+    hookEditor(editor: Quill.Quill): void;
+    unhookEditor(editor: Quill.Quill): void;
+    setEditorReadOnly(editor: Quill.Quill, value: boolean);
+    setEditorContents(editor: Quill.Quill, value: Quill.Delta | string);
+    setEditorSelection(editor: Quill.Quill, range: Quill.RangeStatic);
+    makeUnprivilegedEditor(editor: Quill.Quill): UnprivilegedEditor;
+}

--- a/types.d.ts
+++ b/types.d.ts
@@ -4,80 +4,101 @@ import * as Quill from "quill";
 type ToolbarOptionItem = string | string[] | Object[];
 
 interface ToolbarOptionObject {
-    container: string;
-    handlers?: {
-        [key: string]: Function;
-    };
+	container: string;
+	handlers?: {
+		[key: string]: Function;
+	};
 }
 
 export interface Modules {
-    toolbar: string | ToolbarOptionObject | ToolbarOptionItem[];
+	/**
+	 * @deprecated
+	 * 'Since v1.0.0, React Quill will not create a custom toolbar for you anymore.
+	 * Create a toolbar explictly, or let Quill create one.
+	 * See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v100
+	 */
+	toolbar?: never;
 }
 
 export interface UnprivilegedEditor {
-    getLength: () => number;
-    getText: () => string;
-    getHTML: () => string;
-    getBounds(index: number, length?: number): Quill.BoundsStatic;
-    getSelection(focus?: boolean): Quill.RangeStatic;
+	getLength: () => number;
+	getText: () => string;
+	getHTML: () => string;
+	getBounds(index: number, length?: number): Quill.BoundsStatic;
+	getSelection(focus?: boolean): Quill.RangeStatic;
 }
 
 export interface ComponentProps {
-    id?: string;
-    className?: string;
-    theme?: string;
-    style?: React.CSSProperties;
-    readOnly?: boolean;
-    value?: string | Quill.Delta;
-    defaultValue?: string | Quill.Delta;
-    placeholder?: string;
-    tabIndex?: number;
-    bounds?: string | HTMLElement;
-    onChange?: (content: string, delta: Quill.Delta, source: Quill.Sources, editor: UnprivilegedEditor) => void;
-    onChangeSelection?: (range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor) => void;
-    onFocus?: (range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor) => void;
-    onBlur?: (previousRange: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor) => void;
-    onKeyPress?: React.EventHandler<any>;
-    onKeyDown?: React.EventHandler<any>;
-    onKeyUp?: React.EventHandler<any>;
-    formats?: string[];
-    children?: React.ReactElement<any>;
-    modules?: Modules;
+	id?: string;
+	className?: string;
+	theme?: string;
+	style?: React.CSSProperties;
+	readOnly?: boolean;
+	value?: string | Quill.Delta;
+	defaultValue?: string | Quill.Delta;
+	placeholder?: string;
+	tabIndex?: number;
+	bounds?: string | HTMLElement;
+	onChange?: (content: string, delta: Quill.Delta, source: Quill.Sources, editor: UnprivilegedEditor) => void;
+	onChangeSelection?: (range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor) => void;
+	onFocus?: (range: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor) => void;
+	onBlur?: (previousRange: Quill.RangeStatic, source: Quill.Sources, editor: UnprivilegedEditor) => void;
+	onKeyPress?: React.EventHandler<any>;
+	onKeyDown?: React.EventHandler<any>;
+	onKeyUp?: React.EventHandler<any>;
+	formats?: string[];
+	children?: React.ReactElement<any>;
+	modules?: Modules;
 
-    // Deprecated props
-    toolbar?: never;
-    styles?: never;
-    pollInterval?: never;
+	/** @deprecated
+	 * The `toolbar` prop has been deprecated. Use `modules.toolbar` instead.
+	 * See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v100.
+	 * */
+
+	toolbar?: never;
+	/** @deprecated
+	 * The `styles` prop has been deprecated. Use custom stylesheets instead.
+	 * See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v100
+	 */
+
+	 styles?: never;
+	/**
+	 * @deprecated
+	 * The `pollInterval` property does not have any effect anymore.
+	 * You can safely remove it from your props.
+	 * See: https://github.com/zenoamaro/react-quill#upgrading-to-react-quill-v100.
+	 */
+	pollInterval?: never;
 }
 
 export default class Component extends React.Component<ComponentProps> {
-    focus(): void;
-    blur(): void;
-    getEditor(): Quill.Quill;
+	focus(): void;
+	blur(): void;
+	getEditor(): Quill.Quill;
 }
 
 export interface ToolbarItem {
-    type: string;
-    label?: string;
-    value?: string;
-    items?: ToolbarItem[];
+	type: string;
+	label?: string;
+	value?: string;
+	items?: ToolbarItem[];
 }
 
 export interface ToolbarProps {
-    id?: string;
-    className?: string;
-    style?: Object;
-    items?: ToolbarItem[];
+	id?: string;
+	className?: string;
+	style?: Object;
+	items?: ToolbarItem[];
 }
 
 export class Toolbar extends React.Component<ToolbarProps> {}
 
 export interface Mixin {
-    createEditor(element: HTMLElement, config: Quill.QuillOptionsStatic): Quill.Quill;
-    hookEditor(editor: Quill.Quill): void;
-    unhookEditor(editor: Quill.Quill): void;
-    setEditorReadOnly(editor: Quill.Quill, value: boolean);
-    setEditorContents(editor: Quill.Quill, value: Quill.Delta | string);
-    setEditorSelection(editor: Quill.Quill, range: Quill.RangeStatic);
-    makeUnprivilegedEditor(editor: Quill.Quill): UnprivilegedEditor;
+	createEditor(element: HTMLElement, config: Quill.QuillOptionsStatic): Quill.Quill;
+	hookEditor(editor: Quill.Quill): void;
+	unhookEditor(editor: Quill.Quill): void;
+	setEditorReadOnly(editor: Quill.Quill, value: boolean);
+	setEditorContents(editor: Quill.Quill, value: Quill.Delta | string);
+	setEditorSelection(editor: Quill.Quill, range: Quill.RangeStatic);
+	makeUnprivilegedEditor(editor: Quill.Quill): UnprivilegedEditor;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,14 @@
   version "6.0.78"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-6.0.78.tgz#5d4a3f579c1524e01ee21bf474e6fba09198f470"
 
+"@types/quill@*":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@types/quill/-/quill-1.3.3.tgz#06e08fb017d9493e3708c5c13fbb8bf33ad03d9e"
+
+"@types/react@*":
+  version "16.0.10"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.0.10.tgz#a24b630f5f1f170866a148a147d4fc8636ea88e0"
+
 abab@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.3.tgz#b81de5f7274ec4e756d797cd834f303642724e5d"


### PR DESCRIPTION
Fulfilling #269 This PR adds TypeScript type definitions to this project. These definitions build on top of the existing `@types/react` and `@types/quill` packages.

I've added definitions for:
- Mixin
- Component
- Toolbar

The dependancy versions of those are set to `*` so that they'll match whatever version that the user of this project has installed.

---

Closes #269 