### PR TITLE
Updated Quill to 1.3.4.

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "create-react-class": "^15.6.0",
     "lodash": "^4.17.4",
     "prop-types": "^15.5.10",
-    "quill": "^1.2.6",
+    "quill": "^1.3.4",
     "react-dom-factories": "^1.0.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Quill since 1.3.0 has a useful 'matchVisual' config option.