### PR TITLE
Add types.d.ts to the produced package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "files": [
     "dist/",
     "lib/",
+    "types.d.ts",
     "README.md",
     "CHANGELOG.md",
     "LICENSE"


### PR DESCRIPTION
Love having the `.d.ts` file, but noticed is wasn't in the latest npm package.