### PR TITLE
Fix issue with unnecessary editor focus on mount

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -65,7 +65,7 @@ var QuillMixin = {
 		var sel = editor.getSelection();
 		
 		if (typeof value === 'string') {
-			editor.clipboard.dangerouslyPasteHTML(value);
+			editor.setContents(editor.clipboard.convert(value));
 		} else {
 			editor.setContents(value);
 		}


### PR DESCRIPTION
`dangerouslyPasteHTML` will always grab editor focus, which is not necessarily desired all the time. This simply moves up the logic without the focus part.