### PR TITLE
Propagate tabindex prop to editor's scroll container

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -272,6 +272,7 @@ var QuillComponent = createClass({
 			modules:      this.props.modules,
 			placeholder:  this.props.placeholder,
 			readOnly:     this.props.readOnly,
+			tabIndex:     this.props.tabIndex,
 			theme:        this.props.theme,
 		};
 	},

--- a/src/component.js
+++ b/src/component.js
@@ -272,7 +272,7 @@ var QuillComponent = createClass({
 			modules:      this.props.modules,
 			placeholder:  this.props.placeholder,
 			readOnly:     this.props.readOnly,
-      scrollingContainer: this.props.scrollingContainer,
+      			scrollingContainer: this.props.scrollingContainer,
 			tabIndex:     this.props.tabIndex,
 			theme:        this.props.theme,
 		};

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -10,6 +10,9 @@ var QuillMixin = {
 	*/
 	createEditor: function($el, config) {
 		var editor = new Quill($el, config);
+		if (config.tabIndex !== undefined) {
+			this.setEditorTabIndex(editor, config.tabIndex);
+		}
 		this.hookEditor(editor);
 		return editor;
 	},
@@ -81,6 +84,12 @@ var QuillMixin = {
 			range.length = Math.max(0, Math.min(range.length, (length-1) - range.index));
 		}
 		editor.setSelection(range);
+	},
+
+	setEditorTabIndex: function(editor, tabIndex) {
+		if (editor.editor && editor.editor.scroll && editor.editor.scroll.domNode) {
+			editor.editor.scroll.domNode.tabIndex = tabIndex;
+		}
 	},
 
 	/*


### PR DESCRIPTION
Until now the `tabIndex` isn't being propagated to the editor's scroll dom node (which is typically a `<div>` with `contenteditable="true"` and can thus be focused via keyboard tabbing). With this change we're propagating the tabindex to said dom node to establish a working tabindex for the editor.

Note: Quill unfortunately doesn't provide an API to set the editor's tabindex, so we have to override it directly on its dom node. Not sure if there's a better place to do it.

Also see https://github.com/zenoamaro/react-quill/issues/232#issuecomment-369199337