### PR TITLE
Ensure only user changes will be undone or redone.

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -130,7 +130,11 @@ var QuillComponent = createClass({
 	getDefaultProps: function() {
 		return {
 			theme: 'snow',
-			modules: {},
+			modules: {
+				history: {
+					userOnly: true,
+				},
+			},
 		};
 	},
 


### PR DESCRIPTION
Without this, Quill will treat calling `setContents` on the editor as an undoable/redoable change, even though the user didn't input it.

See documention on userOnly configuration: https://quilljs.com/docs/modules/history/#useronly
Issue: https://github.com/zenoamaro/react-quill/issues/335