### PR TITLE
Export Quill type definition

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,6 +1,8 @@
 import * as React from "react";
 import * as Quill from "quill";
 
+export { Quill } from "quill";
+
 export interface UnprivilegedEditor {
 	getLength(): number;
 	getText(index?: number, length?: number): string;


### PR DESCRIPTION
Fix error in `ts` file.

```ts
import ReactQuill, { Quill } from "react-quill"; // ts error: No exported member 'Quill'.
```