### PR TITLE
Add Quill as an exported object to typings file

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -85,10 +85,10 @@ declare namespace ReactQuill {
 	}
 }
 
-declare class ReactQuill extends React.Component<ReactQuill.ComponentProps> {
+export default class ReactQuill extends React.Component<ReactQuill.ComponentProps> {
 	focus(): void;
 	blur(): void;
 	getEditor(): Quill.Quill;
 }
 
-export = ReactQuill;
+export { Quill } from "quill";


### PR DESCRIPTION
This is a fix for https://github.com/zenoamaro/react-quill/issues/361.

The problem is that when trying to import Quill from 'react-quill' in Typescript, it complains that react-quill has no exported member named Quill. Looking at the typings file, this is true. This fix adds Quill as an exported member to the typings file.