### PR TITLE
Expose config option scrollingContainer through ReactQuill props

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -267,12 +267,13 @@ var QuillComponent = createClass({
 
 	getEditorConfig: function() {
 		return {
-			bounds:       this.props.bounds,
-			formats:      this.props.formats,
-			modules:      this.props.modules,
-			placeholder:  this.props.placeholder,
-			readOnly:     this.props.readOnly,
-			theme:        this.props.theme,
+			bounds:             this.props.bounds,
+			formats:            this.props.formats,
+			modules:            this.props.modules,
+			placeholder:        this.props.placeholder,
+			readOnly:           this.props.readOnly,
+			theme:              this.props.theme,
+			scrollingContainer: this.props.scrollingContainer,
 		};
 	},
 


### PR DESCRIPTION
Closes #239 