### PR TITLE
(docs) Add makeUnprivilegedEditor example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -679,6 +679,15 @@ class Editor extends React.Component {
 }
 ```
 
+To make an unprivileged editor instance use the ref to pass in the editor:
+
+```jsx
+const editor = this.reactQuillRef.getEditor();
+const unprivilegedEditor = this.reactQuillRef.makeUnprivilegedEditor(editor);
+// You may now use the unprivilegedEditor proxy methods
+unprivilegedEditor.getText();
+```
+
 </details>
 
 ### The unprivileged editor

--- a/README.md
+++ b/README.md
@@ -679,7 +679,15 @@ class Editor extends React.Component {
 }
 ```
 
-To make an unprivileged editor instance use the ref to pass in the editor:
+</details>
+
+
+`makeUnprivilegedEditor`
+: Creates an [unprivileged editor](#unprivileged-editor). Pass this method a reference to the Quill instance from `getEditor`.
+
+
+<details>
+<summary>Example</summary>
 
 ```jsx
 const editor = this.reactQuillRef.getEditor();
@@ -711,7 +719,6 @@ During events, ReactQuill will make a restricted subset of the Quill API availab
 
 `getBounds()`
 : Returns the pixel position, relative to the editor container, and dimensions, of a selection, at a given location.
-
 
 ## Building and testing
 

--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ class Editor extends React.Component {
 
 
 `makeUnprivilegedEditor`
-: Creates an [unprivileged editor](#unprivileged-editor). Pass this method a reference to the Quill instance from `getEditor`.
+: Creates an [unprivileged editor](#unprivileged-editor). Pass this method a reference to the Quill instance from `getEditor`. Normally you do not need to use this method since the editor exposed to event handlers is already unprivileged.
 
 
 <details>


### PR DESCRIPTION
Hi 👋

Thanks for this wrapper around Quill! I wanted to add an example of how to make the unprivileged editor because it didn't seem obvious to me at all how you do that (particularly got tripped up on not realizing I needed to pass the editor to the makeUnprivilegedEditor() fn).

Hope this help!