### PR TITLE
:recycle: add back ts-compatible default export

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ https://github.com/zenoamaro/react-quill
 var Quill = require('quill');
 
 module.exports = require('./component');
+module.exports.default = require('./component');
 module.exports.Quill = Quill;
 module.exports.Mixin = require('./mixin');
 module.exports.Toolbar = require('./toolbar');


### PR DESCRIPTION
Hi there!

A few days ago, a change was introduced that broke TS default import expectations.

The import code specified in the readme isn't valid right now, I believe after this commit was added:
https://github.com/zenoamaro/react-quill/commit/4c15c32eab583af2fc7f42959e214d134958968b

If doing `import * as ReactQuill from 'react-quill';` the returned class won't have constructor or call methods, and it'll cease to work as advertised.

I'm not sure if you're cool with this solution, but I've had to fork a work project with this solution to get things back to work. Let me know what you think!