### PR TITLE
Use editor-change event to call onChange and onChangeSelection properties

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -45,7 +45,7 @@ var QuillMixin = {
 			}
 		}.bind(this);
 
-		editor.on('editor-change', (eventType, rangeOrDelta, oldRangeOrOldDelta, source) => {
+		editor.on('editor-change', function(eventType, rangeOrDelta, oldRangeOrOldDelta, source) {
 			if (eventType === Quill.events.SELECTION_CHANGE) {
 				this.handleSelectionChange(rangeOrDelta, oldRangeOrOldDelta, source);
 			}

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -45,8 +45,15 @@ var QuillMixin = {
 			}
 		}.bind(this);
 
-		editor.on('text-change', this.handleTextChange);
-		editor.on('selection-change', this.handleSelectionChange);
+		editor.on('editor-change', (eventType, rangeOrDelta, oldRangeOrOldDelta, source) => {
+			if (eventType === Quill.events.SELECTION_CHANGE) {
+				this.handleSelectionChange(rangeOrDelta, oldRangeOrOldDelta, source);
+			}
+			
+			if (eventType === Quill.events.TEXT_CHANGE) {
+				this.handleTextChange(rangeOrDelta, oldRangeOrOldDelta, source);
+			}
+		});
 	},
 
 	unhookEditor: function(editor) {

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -53,7 +53,7 @@ var QuillMixin = {
 			if (eventType === Quill.events.TEXT_CHANGE) {
 				this.handleTextChange(rangeOrDelta, oldRangeOrOldDelta, source);
 			}
-		});
+		}.bind(this));
 	},
 
 	unhookEditor: function(editor) {


### PR DESCRIPTION
Closes #381 

![update-selection-immediately](https://user-images.githubusercontent.com/1791066/42283458-cc2af9c4-7fa9-11e8-9fea-6bf94b00145d.gif)

`editor-change`'s selection change seems to more completely cover the cases in which one expects `onChangeSelection` to be called.

Another idea was exposing `onEditorChange` as a prop, and although this might provide better backwards compatibility, it also seems more confusing.

I'm curious to hear whether my proposed approach seems valid, or if you perhaps expect it to break other parts of the wrapper.