### PR TITLE
add key `scrollingContainer` to provide typing

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -22,6 +22,7 @@ declare namespace ReactQuill {
 		placeholder?: string;
 		tabIndex?: number;
 		bounds?: string | HTMLElement;
+		scrollingContainer?: string | HTMLElement;
 		onChange?: (
 			content: string,
 			delta: Quill.Delta,


### PR DESCRIPTION
fix(types.d.ts): add key `scrollingContainer` to provide typing for feature added in https://github.com/zenoamaro/react-quill/pull/365