### PR TITLE
Export ReactQuill namespace

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Quill from "quill";
 
-declare namespace ReactQuill {
+export namespace ReactQuill {
 	export interface UnprivilegedEditor {
 		getLength(): number;
 		getText(index?: number, length?: number): string;


### PR DESCRIPTION
Importing the ReactQuill namespaced types do not work in Typescript. This PR exports the namespace, which allows for the following usage:

    import ReactQuill from 'react-quill'; // Import the React component
    import { ReactQuill as rq } from 'react-quill'; // Import the namespace

Once the namespace is imported, it can be used like so:

    function(editor: rq.UnprivilegedEditor): void { ... }

This fixes https://github.com/zenoamaro/react-quill/issues/350