### PR TITLE
Export ReactQuill namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Special thank you to everyone who contributed during the 1.0.0 release cycle!
 ### Import the component
 
 ```jsx
-import ReactQuill from 'react-quill'; // ES6
-import * as ReactQuill from 'react-quill'; // Typescript
+import ReactQuill from 'react-quill'; // ES6 and Typescript
+import { ReactQuill as rq } from 'react-quill'; // Typescript namespace
 const ReactQuill = require('react-quill'); // CommonJS
 ```
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,7 +1,7 @@
 import * as React from "react";
 import * as Quill from "quill";
 
-declare namespace ReactQuill {
+export namespace ReactQuill {
 	export interface UnprivilegedEditor {
 		getLength(): number;
 		getText(index?: number, length?: number): string;


### PR DESCRIPTION
This is a copy of https://github.com/zenoamaro/react-quill/pull/433. I deleted my fork and recreated the PR since it seems other people are experiencing this problem. 

Importing the ReactQuill namespaced types do not work in Typescript. This PR exports the namespace, which allows for the following usage:

    import ReactQuill from 'react-quill'; // Import the React component
    import { ReactQuill as rq } from 'react-quill'; // Import the namespace

Once the namespace is imported, it can be used like so:

    function(editor: rq.UnprivilegedEditor): void { ... }

This fixes https://github.com/zenoamaro/react-quill/issues/350

Can you take a look @alexkrolick. I also updated the README. 
