### PR TITLE
Add preserveWhitespace prop in TS type definition

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -50,7 +50,7 @@ declare namespace ReactQuill {
 		formats?: string[];
 		children?: React.ReactElement<any>;
 		modules?: Quill.StringMap;
-		preserveWhitespace: boolean;
+		preserveWhitespace?: boolean;
 
 		/** @deprecated
 		 * The `toolbar` prop has been deprecated. Use `modules.toolbar` instead.

--- a/types.d.ts
+++ b/types.d.ts
@@ -50,6 +50,7 @@ declare namespace ReactQuill {
 		formats?: string[];
 		children?: React.ReactElement<any>;
 		modules?: Quill.StringMap;
+		preserveWhitespace: boolean;
 
 		/** @deprecated
 		 * The `toolbar` prop has been deprecated. Use `modules.toolbar` instead.


### PR DESCRIPTION
Adds the preserveWhitespace prop in the TypeScript type definition program, since it was not added in #407 