### PR TITLE
Type Check in Props and Delta Change Values

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -165,12 +165,17 @@ var QuillComponent = createClass({
 		if ('value' in nextProps) {
 			var currentContents = this.getEditorContents();
 			var nextContents = nextProps.value;
-
-			if (nextContents === this.lastDeltaChangeSet) throw new Error(
-				'You are passing the `delta` object from the `onChange` event back ' +
-				'as `value`. You most probably want `editor.getContents()` instead. ' +
-				'See: https://github.com/zenoamaro/react-quill#using-deltas'
-			);
+			
+			if (typeof nextContents !== 'undefined' 
+			&& typeof this.lastDeltaChangeSet !== 'undefined' &&
+			nextContents === this.lastDeltaChangeSet) {
+					throw new Error(
+						'You are passing the `delta` object from the `onChange` event back ' +
+						'as `value`. You most probably want `editor.getContents()` instead. ' +
+						'See: https://github.com/zenoamaro/react-quill#using-deltas'
+					);
+			}
+			 
 
 			// NOTE: Seeing that Quill is missing a way to prevent
 			//       edits, we have to settle for a hybrid between


### PR DESCRIPTION
This PR fixes the issue [issue-498](https://github.com/zenoamaro/react-quill/issues/498)

Added typecheck to avoid throwing onChange Error when `nextContents` and `this.lastDeltaChangeSet` are undefined.

Before Fix:
<img width="1241" alt="Screenshot 2019-10-14 at 12 49 05 AM" src="https://user-images.githubusercontent.com/17050715/66720938-afa90f80-ee1f-11e9-86b6-ce94b209b72f.png">

After Fix:
<img width="1242" alt="Screenshot 2019-10-14 at 12 51 54 AM" src="https://user-images.githubusercontent.com/17050715/66720958-cf403800-ee1f-11e9-8a4a-0655abc4630e.png">



