### PR TITLE
changed lifecycle usages to be react 17 compliant

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -151,7 +151,7 @@ var QuillComponent = createClass({
 		};
 	},
 
-	componentWillReceiveProps: function(nextProps, nextState) {
+	UNSAFE_componentWillReceiveProps: function(nextProps, nextState) {
 		var editor = this.editor;
 
 		// If the component is unmounted and mounted too quickly
@@ -254,7 +254,7 @@ var QuillComponent = createClass({
 	If we could not update settings from the new props in-place, we have to tear
 	down everything and re-render from scratch.
 	*/
-	componentWillUpdate: function(nextProps, nextState) {
+	UNSAFE_componentWillUpdate: function(nextProps, nextState) {
 		if (this.state.generation !== nextState.generation) {
 			this.componentWillUnmount();
 		}


### PR DESCRIPTION
Fixes issue referenced in #523 

React 16.8 and above throws warnings on usages for these now deprecated methods, and they will be removed in React 17, leaving only the `UNSAFE` versions