### PR TITLE
Renaming react lifecycle methods

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -151,7 +151,7 @@ var QuillComponent = createClass({
 		};
 	},
 
-	componentWillReceiveProps: function(nextProps, nextState) {
+	UNSAFE_componentWillReceiveProps: function(nextProps, nextState) {
 		var editor = this.editor;
 
 		// If the component is unmounted and mounted too quickly
@@ -217,7 +217,7 @@ var QuillComponent = createClass({
 		}
 	},
 
-	componentWillUnmount: function() {
+	UNSAFE_componentWillUnmount: function() {
 		var editor; if ((editor = this.getEditor())) {
 			this.unhookEditor(editor);
 			this.editor = null;
@@ -254,9 +254,9 @@ var QuillComponent = createClass({
 	If we could not update settings from the new props in-place, we have to tear
 	down everything and re-render from scratch.
 	*/
-	componentWillUpdate: function(nextProps, nextState) {
+	UNSAFE_componentWillUpdate: function(nextProps, nextState) {
 		if (this.state.generation !== nextState.generation) {
-			this.componentWillUnmount();
+			this.UNSAFE_componentWillUnmount();
 		}
 	},
 


### PR DESCRIPTION
To avoid warnings related to deprecated methods following this blog: https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html

The functionality will remain the same and removing deprecated methods is preferable but not required until the next React major update.