### PR TITLE
Use defaultProps instead of getDefaultProps(deprecated)

### DIFF
--- a/src/component.js
+++ b/src/component.js
@@ -128,11 +128,9 @@ var QuillComponent = createClass({
 		'onKeyUp',
 	],
 
-	getDefaultProps: function() {
-		return {
-			theme: 'snow',
-			modules: {},
-		};
+	defaultProps: {
+		theme: 'snow',
+		modules: {}
 	},
 
 	/*

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -83,10 +83,8 @@ var QuillToolbar = createClass({
 		items:     T.array
 	},
 
-	getDefaultProps: function() {
-		return {
-			items: defaultItems
-		};
+	defaultProps: {
+		items: defaultItems,
 	},
 
 	componentDidMount: function() {


### PR DESCRIPTION
This PR is to fix the following warning(getting with react 16.5.2).
Warning: getDefaultProps is only used on classic React.createClass definitions. Use a static property named `defaultProps` instead.