### PR TITLE
Various fixes for beta

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -398,7 +398,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     }
     // Quill types (erroneously) do not specify that `null` is accepted here.
     this.selection = range;
-    editor.setSelection(range!);
+    if (range) editor.setSelection(range);
   }
 
   setEditorTabIndex(editor: Quill, tabIndex: number) {
@@ -563,7 +563,8 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
 
   blur(): void {
     if (!this.editor) return;
-    this.setEditorSelection(this.editor, null);
+    this.selection = null;
+    this.editor.blur();
   }
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -277,8 +277,9 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
       const {delta, selection} = this.regenerationSnapshot!;
       delete this.regenerationSnapshot;
       this.instantiateEditor();
-      this.editor!.setContents(delta);
-      if (selection) postpone(() => this.editor!.setSelection(selection));
+      const editor = this.editor!;
+      editor.setContents(delta);
+      if (selection) postpone(() => editor.setSelection(selection));
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -263,9 +263,9 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     // to be re-instantiated. Regenerating the editor will cause the whole tree,
     // including the container, to be cleaned up and re-rendered from scratch.
     // Store the contents so they can be restored later.
-    if (this.shouldComponentRegenerate(prevProps)) {
-      const delta = this.editor!.getContents();
-      const selection = this.editor!.getSelection();
+    if (this.editor && this.shouldComponentRegenerate(prevProps)) {
+      const delta = this.editor.getContents();
+      const selection = this.editor.getSelection();
       this.regenerationSnapshot = {delta, selection};
       this.setState({generation: this.state.generation + 1});
       this.destroyEditor();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -390,15 +390,14 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   }
 
   setEditorSelection(editor: Quill, range: Range) {
+    this.selection = range;
     if (range) {
       // Validate bounds before applying.
       const length = editor.getLength();
       range.index = Math.max(0, Math.min(range.index, length-1));
       range.length = Math.max(0, Math.min(range.length, (length-1) - range.index));
+      editor.setSelection(range);
     }
-    // Quill types (erroneously) do not specify that `null` is accepted here.
-    this.selection = range;
-    if (range) editor.setSelection(range);
   }
 
   setEditorTabIndex(editor: Quill, tabIndex: number) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -278,7 +278,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
       delete this.regenerationSnapshot;
       this.instantiateEditor();
       this.editor!.setContents(delta);
-      postpone(() => this.editor!.setSelection(selection!));
+      if (selection) postpone(() => this.editor!.setSelection(selection));
     }
   }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -284,9 +284,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   }
 
   instantiateEditor(): void {
-    if (this.editor) {
-      throw new Error('Editor is already instantiated');
-    }
+    if (this.editor) return;
     this.editor = this.createEditor(
       this.getEditingArea(),
       this.getEditorConfig()
@@ -294,9 +292,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   }
 
   destroyEditor(): void {
-    if (!this.editor) {
-      throw new Error('Destroying editor before instantiation');
-    }
+    if (!this.editor) return;
     this.unhookEditor(this.editor);
     delete this.editor;
   }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -279,7 +279,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
       this.instantiateEditor();
       const editor = this.editor!;
       editor.setContents(delta);
-      if (selection) postpone(() => editor.setSelection(selection));
+      postpone(() => this.setEditorSelection(editor, selection));
     }
   }
 


### PR DESCRIPTION
Fixes #495 

It seems that in aa9759742f24f49bc651b1d65fd0e08b4f349d62 this if statement is actually needed. If setSelection is called with `null` then quill explicitly removes focus from *any* element on the screen. So in my usecase typing in another element becomes unfocused after each keystroke due to this.

/cc @jwngr