### PR TITLE
import useState in the first example

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ npm install react-quill --save
 ~~~
 
 ~~~jsx
-import React from 'react';
+import React, {useState} from 'react';
 import ReactQuill from 'react-quill';
 import 'react-quill/dist/quill.snow.css';
 


### PR DESCRIPTION
I've imported the `useState` hook in this example so that it is a quick copy and past job to get it running. Otherwise it might trip a few people up.