### PR TITLE
Add ref to props

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -66,6 +66,7 @@ namespace ReactQuill {
     tabIndex?: number,
     theme?: string,
     value?: Value,
+    ref?: React.Ref<any>
   }
 
   export interface UnprivilegedEditor {


### PR DESCRIPTION
Currently TS disallows adding a ref to the Quill component. This allows a ref to be passed.