### PR TITLE
Fix migration anchor link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This is the documentation for ReactQuill v2 — Previous releases: [v1](/../../t
 
 ReactQuill 2 is here, baby! And it brings a full port to TypeScript and React 16+, a refactored build system, and a general tightening of the internal logic.
 
-We worked hard to avoid introducing any behavioral changes. For the vast majority of the cases, no migration is necessary at all. However, support for long-deprecated props, the ReactQuill Mixin, and the Toolbar component have been removed. Be sure to read the [migration guide](#upgrading-to-react-quill-v2).
+We worked hard to avoid introducing any behavioral changes. For the vast majority of the cases, no migration is necessary at all. However, support for long-deprecated props, the ReactQuill Mixin, and the Toolbar component have been removed. Be sure to read the [migration guide](#upgrading-to-reactquill-v2).
 
 Help us test the beta, and finalize this release! To try it out, simply update the dependency:
 


### PR DESCRIPTION
The migration link in the readme has a typo, this change just fixes that