### PR TITLE
fix: corrected syntax of example code snippet of custom toolbar example 

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,14 +169,14 @@ class MyComponent extends Component {
       ['link', 'image'],
       ['clean']
     ],
-  },
+  }
 
   formats = [
     'header',
     'bold', 'italic', 'underline', 'strike', 'blockquote',
     'list', 'bullet', 'indent',
     'link', 'image'
-  ],
+  ]
 
   render() {
     return (


### PR DESCRIPTION
#700 
Updated readme.
removed the unnecessary comma from the code snippet of [Custom Toolbar](https://github.com/zenoamaro/react-quill#custom-toolbar) in the readme.
