### PR TITLE
Trim tailing empty space

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -476,7 +476,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
         id={this.props.id}
         style={this.props.style}
         key={this.state.generation}
-        className={`quill ${this.props.className ?? ''}`}
+        className={`quill ${this.props.className ?? ''}`.trim()}
         onKeyPress={this.props.onKeyPress}
         onKeyDown={this.props.onKeyDown}
         onKeyUp={this.props.onKeyUp}


### PR DESCRIPTION
There is an extra empty space after the default container style `quill` when the prop classNames is null (see below screenshot).


<img width="576" alt="Screen Shot 2021-11-22 at 1 47 58 AM" src="https://user-images.githubusercontent.com/1174101/142839410-d0e0939e-3a54-4119-89d1-16e773f0addc.png">


This PR aims to remove this extra space.
