### PR TITLE
Fix events not firing in strict mode

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -284,11 +284,14 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
   }
 
   instantiateEditor(): void {
-    if (this.editor) return;
-    this.editor = this.createEditor(
-      this.getEditingArea(),
-      this.getEditorConfig()
-    );
+    if (this.editor) {
+      this.hookEditor(this.editor);
+    } else {
+      this.editor = this.createEditor(
+        this.getEditingArea(),
+        this.getEditorConfig()
+      );
+    }
   }
 
   destroyEditor(): void {


### PR DESCRIPTION
Fix bug mentioned [here](https://github.com/zenoamaro/react-quill/issues/784#issuecomment-1166342710) and introduced in #793.