### PR TITLE
Force editor reinstantiation on generation change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix issue where editor disappears after certain prop changes (#836)
+
 ## v2.0.0
 
 - Fully ported to TypeScript (#549)

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -276,6 +276,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     if (this.state.generation !== prevState.generation) {
       const {delta, selection} = this.regenerationSnapshot!;
       delete this.regenerationSnapshot;
+      delete this.editor;
       this.instantiateEditor();
       const editor = this.editor!;
       editor.setContents(delta);


### PR DESCRIPTION
* This fixes an issue (#836) where the editor disappears on certain prop changes