### PR TITLE
fix: remove extra blank end line

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -530,7 +530,7 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
       this.lastDeltaChangeSet = delta;
 
       this.value = nextContents;
-      this.props.onChange?.(value, delta, source, editor);
+      this.props.onChange?.(value?.replace(/(^([ ]*<p><br><\/p>)*)|((<p><br><\/p>)*[ ]*$)/gi, '').trim(), delta, source, editor);
     }
   }
 


### PR DESCRIPTION
![image](https://github.com/zenoamaro/react-quill/assets/78671853/edc8ebd4-7dcc-4036-bcab-a8ede0729a1b)
1. enter some text 
2. delete all
3. the editor value is a blank line `<p><br></p>`

This does not match the expected result
