### PR TITLE
Five Years NPM Downloads Trend Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ReactQuill [![Build Status](https://travis-ci.org/zenoamaro/react-quill.svg?branch=master)](https://travis-ci.org/zenoamaro/react-quill) [![npm](https://img.shields.io/npm/v/react-quill.svg)](https://www.npmjs.com/package/react-quill)
-[![npm downloads](https://img.shields.io/npm/dt/react-quill.svg?maxAge=2592000)](http://www.npmtrends.com/react-quill)
+[![npm downloads](https://img.shields.io/npm/dt/react-quill.svg?maxAge=2592000)](https://npm-compare.com/react-quill/#timeRange=FIVE_YEARS)
 ==============================================================================
 
 A [Quill] component for [React].


### PR DESCRIPTION
Dear react-quill team,

I hope you're doing well! I’d like to suggest updating the current NPM trends link in the README to one that points to the download trends page on npm-compare.com, which supports viewing the trend data over the past five years. Unlike the link to npmtrends.com, which doesn’t allow specifying a time range, npm-compare.com provides a dynamic chart that visualizes the [download trends for react-quill](https://npm-compare.com/react-quill/#timeRange=FIVE_YEARS) over five-year period.

As a maintainer of npm-compare.com, I believe this enhancement would provide users with better insight into the growing popularity of react-quill over time, which could help them make more informed decisions. If you need any additional features or insights from npm-compare.com, I’d be happy to implement them for the project.

Thank you for considering my suggestion. 