### PR TITLE
fix: Ensure the ReactQuill component reapplies the tabIndex prop to the underlying editor whenever the prop changes, keeping the editor’s focus behavior in sync with React state

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -281,6 +281,10 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
       editor.setContents(delta);
       postpone(() => this.setEditorSelection(editor, selection));
     }
+
+    if (this.editor && this.props.tabIndex !== prevProps.tabIndex) {
+      this.setEditorTabIndex(this.editor, this.props.tabIndex);
+    }
   }
 
   instantiateEditor(): void {
@@ -402,9 +406,13 @@ class ReactQuill extends React.Component<ReactQuillProps, ReactQuillState> {
     }
   }
 
-  setEditorTabIndex(editor: Quill, tabIndex: number) {
-    if (editor?.scroll?.domNode) {
-      (editor.scroll.domNode as HTMLElement).tabIndex = tabIndex;
+  setEditorTabIndex(editor: Quill, tabIndex?: number) {
+    const node = editor?.scroll?.domNode as HTMLElement | undefined;
+    if (!node) return;
+    if (tabIndex != null) {
+      node.tabIndex = tabIndex;
+    } else {
+      node.removeAttribute('tabindex');
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -14,6 +14,7 @@ const { Quill } = require('../lib/index');
 const {
   mountReactQuill,
   getQuillInstance,
+  getQuillDOMNode,
   getQuillContentsAsHTML,
   setQuillContentsFromHTML,
   withMockedConsole,
@@ -183,6 +184,13 @@ describe('<ReactQuill />', function() {
     const wrapper = mountReactQuill({}, editingArea);
     const quill = getQuillInstance(wrapper);
     expect(wrapper.getDOMNode().querySelector('div#venus')).not.to.be.null;
+  });
+
+  it('updates tabIndex on the editor when the prop changes', () => {
+    const wrapper = mountReactQuill({ tabIndex: 3 });
+    expect(getQuillDOMNode(wrapper).tabIndex).to.equal(3);
+    wrapper.setProps({ tabIndex: 5 });
+    expect(getQuillDOMNode(wrapper).tabIndex).to.equal(5);
   });
 
   /**


### PR DESCRIPTION
- Ensured the ReactQuill component reapplies the tabIndex prop to the underlying editor whenever the prop changes, keeping the editor’s focus behavior in sync with React state

- Extended setEditorTabIndex to handle undefined values, removing the attribute when necessary

- Added a unit test verifying that updating the tabIndex prop reflects on the editor DOM node